### PR TITLE
fix(leaderboard): respect permissions by use of get_list

### DIFF
--- a/eps/eps/leaderboard.py
+++ b/eps/eps/leaderboard.py
@@ -29,7 +29,7 @@ def get_energy_point_leaderboard(date_range, company=None, field=None, limit=Non
 	if date_range:
 		date_range = frappe.parse_json(date_range)
 		filters.append(["creation", "between", [date_range[0], date_range[1]]])
-	energy_point_users = frappe.get_all(
+	energy_point_users = frappe.get_list(
 		"Energy Point Log",
 		fields=["user as name", {"SUM": "points", "as": "value"}],
 		filters=filters,


### PR DESCRIPTION
**fix(leaderboard):** This PR aims to fix a permission issue with respect to `leaderboard.py` wherein instead of using `get_list`, `get_all` was being used and this caused permissions to be overlooked. Switching to use `frappe.get_list` instead so permissions are respected.

**Before**:
Permissions were ignored.

**After**:
Permissions are respected.

related to [Ticket #56598](https://support.frappe.io/helpdesk/tickets/56598?view=VIEW-HD+Ticket-003)